### PR TITLE
System should not allow to create any transaction on a Group Company

### DIFF
--- a/netforce/netforce/access.py
+++ b/netforce/netforce/access.py
@@ -299,3 +299,12 @@ def check_permission_other(perm):
         return True
     else:
         return False
+
+def allow_create_transaction():
+    db = database.get_connection()
+    allow=True
+    if _active_company:
+        res=db.query("select prevent_trans from company where id=%s"%(_active_company))
+        if res:
+            allow=not res[0]['prevent_trans']
+    return allow

--- a/netforce_general/netforce_general/layouts/company_form.xml
+++ b/netforce_general/netforce_general/layouts/company_form.xml
@@ -4,6 +4,7 @@
     <field name="code"/>
     <field name="description"/>
     <field name="contact_id"/>
+    <field name="prevent_trans" help="Not allow to create any transaction"/>
     <related>
         <field name="comments"/>
     </related>

--- a/netforce_general/netforce_general/models/company.py
+++ b/netforce_general/netforce_general/models/company.py
@@ -36,6 +36,7 @@ class Company(Model):
         "description": fields.Text("Description"),
         "comments": fields.One2Many("message", "related_id", "Comments"),
         "contact_id": fields.Many2One("contact","Contact"),
+        'prevent_trans': fields.Boolean("Prevent Transaction"),
     }
     _order = "name"
     _constraints = ["_check_cycle"]


### PR DESCRIPTION
except reports (since some reports will also create a record when click
run report). This is quite important since many customers with
multi-company can do the mistake and hard to fix it.