### PR TITLE
IMPROVE : support value return type of flash when click <item/> 

### DIFF
--- a/netforce_ui/netforce_ui/templates/flash.hbs
+++ b/netforce_ui/netforce_ui/templates/flash.hbs
@@ -1,6 +1,6 @@
 {{#if flash}}
     {{#ifeq flash.type "warning"}}
-        <div class="alert">
+        <div class="alert alert-warning">
             <a class="close" data-dismiss="alert" href="#">&times;</a>
             {{{flash.message}}}
         </div>

--- a/netforce_ui/netforce_ui/views/item.js
+++ b/netforce_ui/netforce_ui/views/item.js
@@ -192,7 +192,11 @@ var Item=NFView.extend({
                                 return;
                             }
                             if (data && data.flash) {
-                                set_flash("success",data.flash);
+                                if (_.isString(data.flash)) {
+                                    set_flash("success",data.flash);
+                                } else if (_.isObject(data.flash)) {
+                                    set_flash(data.flash.type,data.flash.message);
+                                }
                             }
                             if (data && data.context) {
                                 set_context(data.context);


### PR DESCRIPTION
IMPROVE : support value return type of flash when click <item/> like <button/> and support type warning alert
    ########################
    EX: return {
        'flash' : {
            'type' : 'warning' ,
            'message' : 'test message for flash'
        }
    }