### PR TITLE
can not use agg_cost_amount in work_time_analysis because it's removed

### DIFF
--- a/netforce_service/netforce_service/actions/work_time_analysis.xml
+++ b/netforce_service/netforce_service/actions/work_time_analysis.xml
@@ -3,6 +3,6 @@
     <field name="view_cls">report_view</field>
     <field name="model">work.time</field>
     <field name="group_select">project_id,resource_id</field>
-    <field name="function_select">agg_actual_hours_total,agg_bill_hours_total,agg_cost_amount</field>
+    <field name="function_select">agg_actual_hours_total,agg_bill_hours_total</field>
     <field name="menu">service_menu</field>
 </action>

--- a/netforce_ui/netforce_ui/views/form_popup.js
+++ b/netforce_ui/netforce_ui/views/form_popup.js
@@ -166,6 +166,7 @@ var FormPopup=NFView.extend({
                     link: $el.attr("link"),
                     view: $el.attr("view"),
                     count: $el.attr("count"),
+                    string: $el.attr("string"),
                     form_layout: form_layout,
                     context: context
                 };


### PR DESCRIPTION
agg_cost_amount is removed from model work.time (by Thanachai) for some reason and it effect to action workt_time_analysis because we use that