### PR TITLE
 translate field file & can not empty field's value in form_list 

### DIFF
--- a/netforce_ui/netforce_ui/templates/field_file.hbs
+++ b/netforce_ui/netforce_ui/templates/field_file.hbs
@@ -1,6 +1,6 @@
 {{#unless options.nolabel}}
     <label class="control-label {{#if horizontal}}col-sm-4{{/if}}">
-        {{string}}
+        {{t string}}
     </label>
 {{/unless}}
 <div class="{{#if horizontal}}col-sm-8{{/if}}">

--- a/netforce_ui/netforce_ui/views/form_list.js
+++ b/netforce_ui/netforce_ui/views/form_list.js
@@ -75,6 +75,12 @@ var FormList=NFView.extend({
                     //log("orig_ids",that.collection.orig_ids);
                     that.collection.on("add",that.render,that);
                     that.collection.on("remove",that.render,that);
+                    that.collection.each(function(model2){
+                        var form_data=_.findWhere(data,{'id': model2.get('id')});
+                        if(form_data){
+                            model2.set_orig_data(form_data);
+                        }
+                    });
                     model.set(name,that.collection);
                     got_collection();
                 });


### PR DESCRIPTION
- translate field file
- can not empty field's value in form_list ex: field "city" of address in organization setting