### PR TITLE
Fix calculate tax from input invioce amount when making Invoice Payment

### DIFF
--- a/netforce_account/netforce_account/models/account_payment.py
+++ b/netforce_account/netforce_account/models/account_payment.py
@@ -257,8 +257,8 @@ class Payment(Model):
                         if inv.inv_type in ("invoice", "credit", "debit"):
                             pay_ratio = line.amount / (inv.amount_total - cred_amt)  # XXX: check this again
                             # get adjust invoice tax
-                            for tax in inv.taxes:
-                                inv_vat+=tax.tax_amount
+                            # for tax in inv.taxes:
+                                # inv_vat+=tax.tax_amount
                             for invline in inv.lines:
                                 invline_amt = invline.amount * pay_ratio
                                 tax = invline.tax_id
@@ -270,7 +270,8 @@ class Payment(Model):
                                         tax.id, base_amt, when="direct_payment")
                                     for comp_id, tax_amt in tax_comps.items():
                                         comp = get_model("account.tax.component").browse(comp_id)
-                                        if comp.type == "vat" and not inv.taxes:
+                                        # if comp.type == "vat" and not inv.taxes:
+                                        if comp.type == "vat":
                                             inv_vat += tax_amt
                                         elif comp.type == "wht":
                                             inv_wht -= tax_amt
@@ -358,8 +359,8 @@ class Payment(Model):
                 if inv.inv_type in ("invoice", "credit", "debit"):
                     pay_ratio = line["amount"] / inv.amount_total
                     # get adjust invoice tax
-                    for tax in inv.taxes:
-                        inv_vat+=tax.tax_amount
+                    # for tax in inv.taxes:
+                        # inv_vat+=tax.tax_amount
                     for invline in inv.lines:
                         invline_amt = invline.amount * pay_ratio
                         tax = invline.tax_id
@@ -371,7 +372,8 @@ class Payment(Model):
                                 tax.id, base_amt, when="direct_payment")
                             for comp_id, tax_amt in tax_comps.items():
                                 comp = get_model("account.tax.component").browse(comp_id)
-                                if comp.type == "vat" and not inv.taxes:
+                                # if comp.type == "vat" and not inv.taxes:
+                                if comp.type == "vat":
                                     inv_vat += tax_amt
                                 elif comp.type == "wht":
                                     wht -= tax_amt


### PR DESCRIPTION
Account Payment (Invoice Payment)

I copy this from aes. In base module, it takes tax amount of the invoice directly without any calculation. So, tax amount is wrong when user change amount by themselves.