### PR TITLE
FIX cms login check

### DIFF
--- a/netforce_general/netforce_general/models/base_user.py
+++ b/netforce_general/netforce_general/models/base_user.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2012-2015 Netforce Co. Ltd.
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -142,6 +142,7 @@ http://nf1.netforce.com/action?name=nfw_reset_passwd&reset_code=%s""" % code
 
     def check_password(self, login, password, context={}):
         db = database.get_connection()
+        login = login.replace("_","\_") ##escape wildcard check '_'
         res = db.get("SELECT id,password FROM base_user WHERE login ILIKE %s", login)
         if not res:
             return None


### PR DESCRIPTION
current code doesnot escape the wildcard '_' during login check causing bug during login

user may register with following for example
1. almacom1test@gmail.com
1. almacom_test@gmail.com

Current code if login = "almacom_test@gmail.com"
res = db.get("SELECT id,password FROM base_user WHERE login ILIKE %s", login) will return
both the emails, and system will try to check password for 1. almacom1test@gmail.com which is wrong.

The simple replace will fix the bug.